### PR TITLE
Build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ deps :
 
 build/Makefile : framework/CMakeLists.txt
 	mkdir -p build/
-	${DEPS_ENV} cmake -U -Bbuild -H.  -DAPPS="${APPS}"  ${DEPS_ARGS} -D"CMAKE_MODULE_PATH:PATH=${ROOT_DIR}/cmake_modules"
+	cd build; ${DEPS_ENV} cmake -U -Bbuild -H.  -DAPPS="${APPS}"  ${DEPS_ARGS} -D"CMAKE_MODULE_PATH:PATH=${ROOT_DIR}/cmake_modules" ..
 
 
 .PHONY: build/Makefile 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -23,12 +23,16 @@ if (CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}     -Wno-error=implicit-fallthrough= -Wno-int-in-bool-context ")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=implicit-fallthrough= -Wno-int-in-bool-context ")
   endif()
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}     -Wno-error=deprecated-copy")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-copy")
+  endif()
 endif()
 
 set(OPTFLAGS "-O3")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${OPTFLAGS}                 -Wall -Wno-unknown-pragmas -Wextra -Wno-error=deprecated-copy -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${OPTFLAGS} --std=c++11 -Wall -Wno-unknown-pragmas -Wextra -Wno-error=deprecated-copy -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${OPTFLAGS}                 -Wall -Wno-unknown-pragmas -Wextra -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${OPTFLAGS} --std=c++11 -Wall -Wno-unknown-pragmas -Wextra -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder")
 
 
 if(APPLE)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -27,8 +27,8 @@ endif()
 
 set(OPTFLAGS "-O3")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${OPTFLAGS}                 -Wall -Wno-unknown-pragmas -Wextra  -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${OPTFLAGS} --std=c++11 -Wall -Wno-unknown-pragmas -Wextra  -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${OPTFLAGS}                 -Wall -Wno-unknown-pragmas -Wextra -Wno-error=deprecated-copy -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${OPTFLAGS} --std=c++11 -Wall -Wno-unknown-pragmas -Wextra -Wno-error=deprecated-copy -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
 
 
 if(APPLE)

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -22,13 +22,16 @@ if (CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}     -Wno-error=implicit-fallthrough= -Wno-int-in-bool-context ")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=implicit-fallthrough= -Wno-int-in-bool-context ")
   endif()
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}     -Wno-error=deprecated-copy")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-copy")
+  endif()
 endif()
 
 set(OPTFLAGS "-O3")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${OPTFLAGS}                 -Wall -Wno-unknown-pragmas -Wextra -Werror -Wno-error=deprecated-copy -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${OPTFLAGS} --std=c++11 -Wall -Wno-unknown-pragmas -Wextra -Werror -Wno-error=deprecated-copy -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
-
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${OPTFLAGS}                 -Wall -Wno-unknown-pragmas -Wextra -Werror -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${OPTFLAGS} --std=c++11 -Wall -Wno-unknown-pragmas -Wextra -Werror -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder")
 
 if(APPLE)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__APPLE__")

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -26,8 +26,8 @@ endif()
 
 set(OPTFLAGS "-O3")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${OPTFLAGS}                 -Wall -Wno-unknown-pragmas -Wextra -Werror -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${OPTFLAGS} --std=c++11 -Wall -Wno-unknown-pragmas -Wextra -Werror -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${OPTFLAGS}                 -Wall -Wno-unknown-pragmas -Wextra -Werror -Wno-error=deprecated-copy -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${OPTFLAGS} --std=c++11 -Wall -Wno-unknown-pragmas -Wextra -Werror -Wno-error=deprecated-copy -Wno-error=deprecated-declarations -Wno-error=unused-result -Wno-error=reorder ")
 
 
 if(APPLE)

--- a/framework/shared/include/values/Value.h
+++ b/framework/shared/include/values/Value.h
@@ -92,11 +92,9 @@ namespace slambench {
 			ValueType value_type_;
 		};
 		
-		// Templates for converting between VTs and classes
-		// weird sizeof checks are to force the checks only to happen when the
-		// template is instantiated, rather than where it is declared
-		template <ValueType T> struct TypeForVT { static_assert(sizeof(T) == -1, "Unknown VT type"); typedef void* type; };
-		template<typename T> struct VTForType { static_assert(sizeof(T) == -1, "No VT for that type"); static constexpr ValueType value() { return VT_UNKNOWN; } };
+		// Fail if no specializations are provided
+		template<ValueType T> struct TypeForVT;
+		template<typename T> struct VTForType;
 		
 		template<typename T> class TypedValue : public Value {
 		public:

--- a/framework/shared/src/metrics/power_utils/PAPIMonitor.cpp
+++ b/framework/shared/src/metrics/power_utils/PAPIMonitor.cpp
@@ -107,7 +107,7 @@ bool PAPIMonitor::papi_init () {
 			return false;
 		}
 
-		strncpy(units[num_events],evinfo.units,sizeof(units[0])-1);
+		strncpy(units[num_events],evinfo.units,sizeof(units[0]));
 		// buffer must be null terminated to safely use strstr operation on it below
 		units[num_events][sizeof(units[0])-1] = '\0';
 


### PR DESCRIPTION
Couldn't build slambench

- make slambench was overwriting the Makefile from the root
- some compile errors
- Wdeprecated-copy introduced by gcc9 was causing errors (we're compiling with Werror)