### PR TITLE
Fix hardcoded assumptions about depth.

### DIFF
--- a/framework/shared/src/io/SLAMFrame.cpp
+++ b/framework/shared/src/io/SLAMFrame.cpp
@@ -470,7 +470,7 @@ void* ImageFileFrame::LoadPng() {
 					size_t index = y * width * 2 + x * 2;
 
 					int r = pixels[index + 0] * 256 + pixels[index + 1];
-					((uint16_t*)outdata)[k++] = r / 5;
+					((uint16_t*)outdata)[k++] = r;
 				}
 			}
 

--- a/framework/tools/dataset-tools/ICL.cpp
+++ b/framework/tools/dataset-tools/ICL.cpp
@@ -655,7 +655,7 @@ SLAMFile* ICLReader::GenerateSLAMFile () {
     }
 
 
-    DepthSensor::disparity_params_t disparity_params =  {0.005,0.0};
+    DepthSensor::disparity_params_t disparity_params =  {0.001,0.0};
     DepthSensor::disparity_type_t disparity_type = DepthSensor::affine_disparity;
 
 

--- a/framework/tools/dataset-tools/include/BONN.h
+++ b/framework/tools/dataset-tools/include/BONN.h
@@ -39,7 +39,7 @@ namespace slambench {
       static constexpr DepthSensor::distortion_coefficients_t distortion_depth =
           {0.039903, -0.099343, -0.000730, -0.000144, 0.000000};
 
-      static constexpr DepthSensor::disparity_params_t disparity_params = {0.001, 0.0};
+      static constexpr DepthSensor::disparity_params_t disparity_params = {0.0002, 0.0};
       static constexpr DepthSensor::disparity_type_t disparity_type = DepthSensor::affine_disparity;
 
      public:

--- a/framework/tools/dataset-tools/include/ICLNUIM.h
+++ b/framework/tools/dataset-tools/include/ICLNUIM.h
@@ -30,7 +30,7 @@ namespace slambench {
       CameraSensor *grey_sensor = nullptr;
       GroundTruthSensor *gt_sensor = nullptr;
 
-      static constexpr DepthSensor::disparity_params_t disparity_params = {0.001, 0.0};
+      static constexpr DepthSensor::disparity_params_t disparity_params = {0.0002, 0.0};
       static constexpr DepthSensor::disparity_type_t disparity_type = DepthSensor::affine_disparity;
 
       void AddSensors(SLAMFile &file);

--- a/framework/tools/dataset-tools/include/TUM.h
+++ b/framework/tools/dataset-tools/include/TUM.h
@@ -32,7 +32,7 @@ namespace slambench {
       static constexpr CameraSensor::intrinsics_t fr2_intrinsics_rgb = {0.81390624, 1.085416667, 0.5079687, 0.52020};
       static constexpr DepthSensor::intrinsics_t fr2_intrinsics_depth = {0.9075, 1.212083333, 0.4825, 0.52708};
 
-      static constexpr DepthSensor::disparity_params_t disparity_params = {0.001, 0.0};
+      static constexpr DepthSensor::disparity_params_t disparity_params = {0.0002, 0.0};
       static constexpr DepthSensor::disparity_type_t disparity_type = DepthSensor::affine_disparity;
 
       //// Taken from https://vision.in.tum.de/data/datasets/rgbd-dataset/file_formats


### PR DESCRIPTION
Requires rebuilding datasets, as parameters had to be adjusted as well. 
Change already tested in SB4